### PR TITLE
Forcing encoder UTF-8

### DIFF
--- a/lib/headers/headers_handler.py
+++ b/lib/headers/headers_handler.py
@@ -1,7 +1,7 @@
 import random
 
 def load_user_agents():
-    with open('lib/headers/user_agents.txt', 'r') as file:
+    with open('lib/headers/user_agents.txt' ,'r', encoding="utf-8") as file:
         return [line.strip() for line in file]
 
 def user_agents():


### PR DESCRIPTION
The encoder used to open file in python depend on the local's system setting and that may vary from one person to another . i faced problems at first but forcing it to use UTF-8 encoder in headers_handler fix the problem